### PR TITLE
feature: Allow custom RowKey values

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The `AzureTableStorageRepository` provides a couple of public APIs and Interface
   @Get(':rowKey')
   async getContact(@Param('rowKey') rowKey) {
     try {
-      return await this.contactService.find(rowKey, new ContactEntity());
+      return await this.contactService.find(rowKey, new Contact());
     } catch (error) {
       // Entity not found
       throw new UnprocessableEntityException(error);
@@ -226,7 +226,7 @@ The `AzureTableStorageRepository` provides a couple of public APIs and Interface
   @Put(':rowKey')
   async saveContact(@Param('rowKey') rowKey, @Body() contactData: ContactDTO) {
     try {
-      const contactEntity = new ContactEntity();
+      const contactEntity = new Contact();
       // Disclaimer: Assign only the properties you are expecting!
       Object.assign(contactEntity, contactData);
 
@@ -238,7 +238,7 @@ The `AzureTableStorageRepository` provides a couple of public APIs and Interface
   @Patch(':rowKey')
   async updateContactDetails(@Param('rowKey') rowKey, @Body() contactData: Partial<ContactDTO>) {
     try {
-      const contactEntity = new ContactEntity();
+      const contactEntity = new Contact();
       // Disclaimer: Assign only the properties you are expecting!
       Object.assign(contactEntity, contactData);
 
@@ -258,7 +258,7 @@ The `AzureTableStorageRepository` provides a couple of public APIs and Interface
   @Delete(':rowKey')
   async deleteDelete(@Param('rowKey') rowKey) {
     try {
-      const response = await this.contactService.delete(rowKey, new ContactEntity());
+      const response = await this.contactService.delete(rowKey, new Contact());
 
       if (response.statusCode === 204) {
         return null;

--- a/README.md
+++ b/README.md
@@ -184,13 +184,16 @@ The `AzureTableStorageRepository` provides a couple of public APIs and Interface
 
 ##### CREATE
 
-`create(entity: T): Promise<T>`: creates a new entity.
+`create(entity: T, rowKeyValue?: string): Promise<T>`: creates a new entity.
 
 ```typescript
-  @Get()
-  async getAllContacts() {
-    return await this.contactService.findAll();
-  }
+
+  @Post()
+  async create(contact: Contact, rowKeyValue: string): Promise<Contact> {
+        //if rowKeyValue is null, rowKeyValue will generate a UUID
+        return this.contactRepository.create(contact, rowKeyValue)
+    }
+
 ```
 
 ##### READ

--- a/lib/table-storage/azure-table.interface.ts
+++ b/lib/table-storage/azure-table.interface.ts
@@ -32,7 +32,7 @@ export interface Repository<T> {
 
   find(rowKey: string, entity: Partial<T>): Promise<T>;
 
-  create(entity: T): Promise<T>;
+  create(entity: T, rowKeyValue?: string): Promise<T>;
 
   update(rowKey: string, entity: Partial<T>): Promise<T>;
 

--- a/lib/table-storage/azure-table.mapper.ts
+++ b/lib/table-storage/azure-table.mapper.ts
@@ -33,7 +33,7 @@ export class AzureEntityMapper {
 
     return result;
   }
-  static createEntity<D>(partialDto: Partial<AzureEntityMapper>, rowKeyValue = generateUuid()) {
+  static createEntity<D>(partialDto: Partial<AzureEntityMapper>, rowKeyValue: string) {
     // Note: make sure we are getting the metatadat from the DTO constructor
     // See: src/table-storage/azure-table.repository.ts
     const entityDescriptor = Reflect.getMetadata(AZURE_TABLE_ENTITY, partialDto.constructor) as PartitionRowKeyValues;
@@ -44,7 +44,9 @@ export class AzureEntityMapper {
         entityDescriptor[key]._ = partialDto[key];
       }
     }
-
+    if (null == rowKeyValue) {
+      rowKeyValue = generateUuid();
+    }
     // make sure we have a unique RowKey
     entityDescriptor.RowKey._ = rowKeyValue;
 

--- a/lib/table-storage/azure-table.repository.ts
+++ b/lib/table-storage/azure-table.repository.ts
@@ -104,10 +104,10 @@ export class AzureTableStorageRepository<T> implements Repository<T> {
     return Object.entries(mappedEntity).length === 0 ? null : mappedEntity;
   }
 
-  async create(entity: T): Promise<T> {
+  async create(entity: T, rowKeyValue?: string): Promise<T> {
     logger.debug(`Inserting Entity in ${this.tableName}:`);
 
-    entity = AzureEntityMapper.createEntity<T>(entity);
+    entity = AzureEntityMapper.createEntity<T>(entity, rowKeyValue);
     // tslint:disable-next-line: no-console
     console.table(entity);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, RowKeys are created as generated UUIDs - while this always ends up with a unique RowKey, sometimes there is already a unique value that could be used instead - this will improve the usability of the solution.

Issue Number: #21 


## What is the new behavior?

The ability to define custom RowKey values.

To use this new feature, all we need to do is define the rowKeyValue in the service and define what we want the rowKeyValue to be in the controller as shown below.

`contact.service.ts
``` TypeScript
async create(contact: Contact, rowKeyValue: string): Promise<Contact> {
    return this.contactRepository.create(contact, rowKeyValue)
}
```

`contact.controller.ts
``` TypeScript
@Post()
    async createContact(
        @Body()
        contactData: ContactDTO,
    ) {
        try {
            const contact = new Contact();
            // in this example the entity contains an item named "Id" that is the unique value we want to use as the RowKey.
            const rowKeyValue = contactData.Id;
            Object.assign(contact, contactData);

            return await this.contactService.create(contact, rowKeyValue);
        } catch (error) {
            throw new UnprocessableEntityException(error);
        }
    }
```
If we do not define the value of rowKeyValue, then the value of rowKeyValue is set by the generateUuid() function.
## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information