### PR TITLE
bugfix(@nestjs/azure-database) stop entityDescriptor mutations in AzureEntityMapper.createEntity()

### DIFF
--- a/lib/table-storage/azure-table.mapper.spec.ts
+++ b/lib/table-storage/azure-table.mapper.spec.ts
@@ -1,0 +1,32 @@
+import { AZURE_TABLE_ENTITY } from './azure-table.decorators';
+import { AzureEntityMapper, PartitionRowKeyValues } from './azure-table.mapper';
+
+class MockEntity {
+  foo: string;
+}
+
+describe('AzureEntityMapper', () => {
+  describe('createEntity()', () => {
+    it('should always return new entity instance', () => {
+      const entityDescriptorMock: PartitionRowKeyValues & any = {
+        RowKey: { _: '', $: '' },
+        PartitionKey: { _: '', $: '' },
+        foo: { _: '', $: '' },
+      };
+
+      Reflect.defineMetadata(AZURE_TABLE_ENTITY, entityDescriptorMock, MockEntity);
+      Reflect.defineMetadata(AZURE_TABLE_ENTITY, entityDescriptorMock, MockEntity);
+
+      const test = new MockEntity();
+      const test2 = new MockEntity();
+
+      test.foo = 'foo';
+
+      const entity = AzureEntityMapper.createEntity<MockEntity>(test);
+      const entity2 = AzureEntityMapper.createEntity<MockEntity>(test2);
+
+      expect(entity).not.toBe(entity2);
+      expect(entity.foo).not.toEqual(entity2.foo);
+    });
+  });
+});

--- a/lib/table-storage/azure-table.mapper.ts
+++ b/lib/table-storage/azure-table.mapper.ts
@@ -18,7 +18,7 @@ export interface PartitionRowKeyValues {
 
 export class AzureEntityMapper {
   static serializeAll<E>(entriesDescriptor: azure.TableService.EntityMetadata[]): E[] {
-    return entriesDescriptor.map<E>(entry => {
+    return entriesDescriptor.map<E>((entry) => {
       return AzureEntityMapper.serialize<E>(entry);
     });
   }
@@ -37,19 +37,22 @@ export class AzureEntityMapper {
     // Note: make sure we are getting the metatadat from the DTO constructor
     // See: src/table-storage/azure-table.repository.ts
     const entityDescriptor = Reflect.getMetadata(AZURE_TABLE_ENTITY, partialDto.constructor) as PartitionRowKeyValues;
+    const entity: PartitionRowKeyValues = {
+      ...entityDescriptor,
+    };
 
     for (const key in partialDto) {
       if (entityDescriptor[key]) {
-        // update the value propery
-        entityDescriptor[key]._ = partialDto[key];
+        entity[key] = { _: partialDto[key], $: entityDescriptor[key].$ };
       }
     }
-    // make sure we have a unique RowKey
-    entityDescriptor.RowKey._ = rowKeyValue;
+
+    entity.RowKey._ = rowKeyValue;
 
     logger.debug(`Mapped Entity from DTO:`);
     logger.debug(`- PartitionKey=${entityDescriptor.PartitionKey._}`);
     logger.debug(`- RowKey=${rowKeyValue}`);
-    return entityDescriptor as (D & PartitionRowKeyValues);
+
+    return entity as D & PartitionRowKeyValues;
   }
 }


### PR DESCRIPTION
#63  PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
createEntity() method mutates `AZURE_TABLE_ENTITY` metadata which may cause serious problems during entity create/update.
e.g.
1. User creates record (R1) which will populate `entityDescriptor` with new data.
2. User updates record (R2) using partial payload.
3. During (R2) update mapper will merge all missing values from (R1) in to (R2).

Issue Number: N/A

## What is the new behavior?
createEntity() method returns new instance of mapped entity each time is executed without mutating `AZURE_TABLE_ENTITY` metadata.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information