### PR TITLE
fix: uniquekey used wrong key.

### DIFF
--- a/lib/cosmos-db/cosmos-db.providers.ts
+++ b/lib/cosmos-db/cosmos-db.providers.ts
@@ -1,4 +1,4 @@
-import { ContainerDefinition, IndexKind, DataType, Database } from '@azure/cosmos';
+import { ContainerDefinition, Database, DataType, IndexKind } from '@azure/cosmos';
 import { AZURE_COSMOS_DB_ENTITY } from './cosmos-db.decorators';
 import { getConnectionToken, getModelToken, pluralize } from './cosmos-db.utils';
 
@@ -46,7 +46,7 @@ export function createAzureCosmosDbProviders(
         if (entityDescriptor.hasOwnProperty(key)) {
           const element = entityDescriptor[key];
           if (element === 'UniqueKey') {
-            containerOptions.uniqueKeyPolicy.uniqueKeys.push({ paths: [`/${element}`] });
+            containerOptions.uniqueKeyPolicy.uniqueKeys.push({ paths: [`/${key}`] });
           }
         }
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When using the CosmosUniqueKey decorator the key will not be correctly setup in cosmos. Because the element was used instead of the key. Simple typo :-)

Issue Number: N/A


## What is the new behavior?
The annotated property will be used as key. This leads to correct behaviour :-)


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information