### PR TITLE
Azure table : concurrent update

### DIFF
--- a/lib/table-storage/azure-table.repository.ts
+++ b/lib/table-storage/azure-table.repository.ts
@@ -123,7 +123,7 @@ export class AzureTableStorageRepository<T> implements Repository<T> {
 
     entity = AzureEntityMapper.createEntity<T>(entity, rowKey);
 
-    const result = await this.manager.replaceEntity(this.tableName, entity);
+    const result = await this.manager.mergeEntity(this.tableName, entity);
 
     logger.debug(`Entity updated successfuly`);
     // tslint:disable-next-line: no-console

--- a/lib/table-storage/azure-table.service.ts
+++ b/lib/table-storage/azure-table.service.ts
@@ -260,20 +260,16 @@ export class AzureTableStorageService implements azure.TableService {
       });
     });
   }
-
-  mergeEntity<T>(
-    table: string,
-    entityDescriptor: T,
-    options: azure.common.RequestOptions,
-    callback: azure.ErrorOrResult<azure.TableService.EntityMetadata>,
-  ): void;
-  mergeEntity<T>(
-    table: string,
-    entityDescriptor: T,
-    callback: azure.ErrorOrResult<azure.TableService.EntityMetadata>,
-  ): void;
-  mergeEntity(table: any, entityDescriptor: any, options: any, callback?: any) {
-    throw new Error('Method not implemented.');
+  mergeEntity<T>(table: string, entityDescriptor: T, options?: any): Promise<azure.TableService.EntityMetadata> {
+    return new Promise((resolve, reject) => {
+      this.tableServiceInstance.mergeEntity<T>(table, entityDescriptor, options, (error, result) => {
+        if (error) {
+          this.printError(error);
+          reject(error);
+        }
+        resolve(result);
+      });
+    });
   }
   insertOrMergeEntity<T>(
     table: string,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #259

Concurrent updates don't seem to work well when we process two updates at the same time with same PartitionKey but different RowKey.

## What is the new behavior?

This is still in Draft because I need to do more research about the current behavior and I'd like to add tests.

As mentioned in the issue, we could replace `replaceEntity` with `mergeEntity`.

I don't know if this problem comes from `replaceEntity` or if it come from concurrent updates.

We could maybe fix the problem by keeping `replaceEntity` and using `etag` to do something like this:

```ts
replaceEntity<T>(table: string, entityDescriptor: T, options?: any): Promise<azure.TableService.EntityMetadata> {
  return new Promise((resolve, reject) => {
    const entityEtag = entityDescriptor['.metadata'].etag
    this.tableServiceInstance.replaceEntity<T>(table, entityDescriptor, options, (error, result) => {
      if (error) {
        this.printError(error);
        reject(error);
      }
      result['.metadata'].etag = entityEtag;
      resolve(result);
    });
  });
}
```

I would like to have your opinion on this 👍

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information