### PR TITLE
feat: add support for hierarchical partition keys in Azure Cosmos DB

### DIFF
--- a/lib/cosmos-db/cosmos-db.decorators.spec.ts
+++ b/lib/cosmos-db/cosmos-db.decorators.spec.ts
@@ -1,4 +1,5 @@
 import { AZURE_COSMOS_DB_ENTITY, CosmosPartitionKey } from './cosmos-db.decorators';
+import { PartitionKeyDefinitionVersion, PartitionKeyKind } from '@azure/cosmos';
 
 describe('Azure CosmosDB Decorators', () => {
   beforeEach(() => {
@@ -14,6 +15,24 @@ describe('Azure CosmosDB Decorators', () => {
       const metadata = Reflect.getMetadata(AZURE_COSMOS_DB_ENTITY, MockClass);
       expect(metadata).toStrictEqual({
         PartitionKey: 'value',
+      });
+    });
+
+    it('should add a Hierarchical PartitionKey ', () => {
+      @CosmosPartitionKey({
+        paths: ["/name", "/address/zip"],
+        version: PartitionKeyDefinitionVersion.V2,
+        kind: PartitionKeyKind.MultiHash,
+      })
+      class MockClass {}
+
+      const metadata = Reflect.getMetadata(AZURE_COSMOS_DB_ENTITY, MockClass);
+      expect(metadata).toStrictEqual({
+        PartitionKey: {
+          paths: ["/name", "/address/zip"],
+          version: PartitionKeyDefinitionVersion.V2,
+          kind: PartitionKeyKind.MultiHash,
+        },
       });
     });
   });

--- a/sample/cosmos-db/package-lock.json
+++ b/sample/cosmos-db/package-lock.json
@@ -42,7 +42,6 @@
       }
     },
     "../..": {
-      "name": "@nestjs/azure-database",
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
@@ -52,13 +51,13 @@
         "@nestjs/core": "^9.0.0 || ^10.0.0"
       },
       "devDependencies": {
-        "@commitlint/cli": "18.4.3",
-        "@commitlint/config-angular": "18.4.3",
+        "@commitlint/cli": "18.4.4",
+        "@commitlint/config-angular": "18.4.4",
         "@nestjs/testing": "10.3.0",
         "@types/jest": "29.5.11",
         "@types/node": "20.9.4",
-        "@typescript-eslint/eslint-plugin": "6.15.0",
-        "@typescript-eslint/parser": "6.15.0",
+        "@typescript-eslint/eslint-plugin": "6.19.0",
+        "@typescript-eslint/parser": "6.19.0",
         "dotenv": "16.3.1",
         "eslint": "8.56.0",
         "eslint-config-prettier": "9.1.0",
@@ -66,11 +65,11 @@
         "husky": "8.0.3",
         "jest": "29.7.0",
         "lint-staged": "15.2.0",
-        "prettier": "3.1.1",
+        "prettier": "3.2.3",
         "reflect-metadata": "0.1.14",
         "rimraf": "5.0.5",
         "rxjs": "7.8.1",
-        "supertest": "6.3.3",
+        "supertest": "6.3.4",
         "ts-jest": "29.1.1",
         "typescript": "5.3.3"
       },

--- a/sample/cosmos-db/src/event/event.controller.ts
+++ b/sample/cosmos-db/src/event/event.controller.ts
@@ -11,6 +11,8 @@ import {
 import { EventDTO } from './event.dto';
 import { EventService } from './event.service';
 
+const SPLIT_SEP = /[.,|-]+/; // Choose your own separator for the hierarchical partition key
+
 @Controller('event')
 export class EventController {
   constructor(private readonly events: EventService) {}
@@ -22,7 +24,7 @@ export class EventController {
 
   @Get(':type/:id')
   async getEvent(@Param('id') id: string, @Param('type') type: string) {
-    const event = await this.events.getEvent(id, type);
+    const event = await this.events.getEvent(id, type.split(SPLIT_SEP));
     if (event === undefined) {
       throw new NotFoundException('Event not found');
     }
@@ -36,7 +38,7 @@ export class EventController {
 
   @Delete(':type/:id')
   async deleteEvent(@Param('id') id: string, @Param('type') type: string) {
-    return await this.events.deleteEvent(id, type);
+    return await this.events.deleteEvent(id, type.split(SPLIT_SEP));
   }
 
   @Put(':type/:id')
@@ -45,6 +47,6 @@ export class EventController {
     @Param('type') type: string,
     @Body() eventDto: EventDTO,
   ) {
-    return await this.events.updateEvent(id, type, eventDto);
+    return await this.events.updateEvent(id, type.split(SPLIT_SEP), eventDto);
   }
 }

--- a/sample/cosmos-db/src/event/event.dto.ts
+++ b/sample/cosmos-db/src/event/event.dto.ts
@@ -1,6 +1,8 @@
 export class EventDTO {
   id?: string;
   name: string;
-  type: string;
+  type: {
+    label: string;
+  }
   createdAt: Date;
 }

--- a/sample/cosmos-db/src/event/event.entity.ts
+++ b/sample/cosmos-db/src/event/event.entity.ts
@@ -1,9 +1,16 @@
 import { CosmosDateTime, CosmosPartitionKey } from '@nestjs/azure-database';
+import { PartitionKeyDefinitionVersion, PartitionKeyKind } from '@azure/cosmos';
 
-@CosmosPartitionKey('type')
+@CosmosPartitionKey({
+  paths: ['/name', '/type/label'],
+  version: PartitionKeyDefinitionVersion.V2,
+  kind: PartitionKeyKind.MultiHash
+})
 export class Event {
   id?: string;
   name: string;
-  type: string;
+  type: {
+    label: string;
+  }
   @CosmosDateTime() createdAt: Date;
 }

--- a/sample/cosmos-db/src/event/event.service.ts
+++ b/sample/cosmos-db/src/event/event.service.ts
@@ -35,7 +35,7 @@ export class EventService {
     }
   }
 
-  async getEvent(id: string, type: string): Promise<Event> {
+  async getEvent(id: string, type: string | string[]): Promise<Event> {
     try {
       const { resource } = await this.eventContainer
         .item(id, type)
@@ -49,7 +49,7 @@ export class EventService {
 
   async updateEvent(
     id: string,
-    type: string,
+    type: string | string[],
     eventData: EventDTO,
   ): Promise<Event> {
     try {
@@ -72,7 +72,7 @@ export class EventService {
     }
   }
 
-  async deleteEvent(id: string, type: string): Promise<Event> {
+  async deleteEvent(id: string, type: string | string[]): Promise<Event> {
     try {
       const { resource: deleted } = await this.eventContainer
         .item(id, type)


### PR DESCRIPTION
This PR adds support for Hierarchical Partition Keys in Cosmos DB.

```typescript

import { CosmosDateTime, CosmosPartitionKey } from '@nestjs/azure-database';
import { PartitionKeyDefinitionVersion, PartitionKeyKind } from '@azure/cosmos';

@CosmosPartitionKey({
  paths: ['/name', '/type/label'],
  version: PartitionKeyDefinitionVersion.V2,
  kind: PartitionKeyKind.MultiHash
})
export class Event {
  id?: string;
  name: string;
  type: {
    label: string;
  }
  @CosmosDateTime() createdAt: Date;
}
```

See [official docs](https://learn.microsoft.com/en-us/azure/cosmos-db/hierarchical-partition-keys?tabs=javascript-v4%2Carm-json).

Closes #953